### PR TITLE
Allow External DB endpoint for system_db

### DIFF
--- a/lib/ecto_aql/repo.ex
+++ b/lib/ecto_aql/repo.ex
@@ -167,11 +167,10 @@ defmodule EctoAQL.Repo do
       defp collection_type(:edge), do: 3
 
       defp system_db do
-        options = [
+        options = config([
           pool_size: 1,
-          database: "_system",
-          endpoints: "http://localhost:8529"
-        ]
+          database: "_system"
+        ])
 
         Arangox.start_link(options)
       end


### PR DESCRIPTION
Uses the first found repo config for the system_db functions so that an external DB can be used for migrations, etc.

I needed this change because my ArangoDB is hosted on a local network server (therefore not localhost).